### PR TITLE
Updated capability flags for wider support

### DIFF
--- a/bruteforce-erldp.c
+++ b/bruteforce-erldp.c
@@ -211,7 +211,7 @@ static void *worker_run(void *arg) {
   uint64_t challenge;
   char cookie[20];
   uint8_t buffer[256];
-  char send_name[64] = "n" "\x00\x05" "\x00\x07\x7f\xfc";
+  char send_name[64] = "n" "\x00\x05" "\x00\x07\x49\x9c";
   size_t name_length;
   char send_challenge_reply[23] = "\x00\x15" "r" "\x00\x00\x00\x00";
   const int on = 1;

--- a/dictionary-erldp.py
+++ b/dictionary-erldp.py
@@ -23,7 +23,7 @@ parser.add_argument('dictionary', action='store', type=str, help='Dictionary of 
 parser.add_argument('--delay', type=float, default=0.0, help='Amount of seconds (float) to sleep between attempts')
 
 def send_name(name):
-  return pack('!HcHI', 7 + len(name), 'n', 5, 0x3499c) + name
+  return pack('!HcHI', 7 + len(name), 'n', 5, 0x7499c) + name
 
 def send_challenge_reply(cookie, challenge):
   m = md5()

--- a/erldp-info.nse
+++ b/erldp-info.nse
@@ -104,7 +104,7 @@ action = function(host, port)
     return
   end
 
-  send_name = bin.pack('>SCSIA', 7+string.len(local_name), 110, 5, 0x3499c, local_name)
+  send_name = bin.pack('>SCSIA', 7+string.len(local_name), 110, 5, 0x7499c, local_name)
 
   if not client:send(send_name) then
     client:close()

--- a/shell-erldp.py
+++ b/shell-erldp.py
@@ -33,7 +33,7 @@ assert(sock)
 sock.connect((args.target, args.port))
 
 def send_name(name):
-  return pack('!HcHI', 7 + len(name), 'n', 5, 0x3499c) + name
+  return pack('!HcHI', 7 + len(name), 'n', 5, 0x7499c) + name
 
 sock.sendall(send_name(name))
 

--- a/sweep-default-cookie.py
+++ b/sweep-default-cookie.py
@@ -22,7 +22,7 @@ parser.add_argument('targets', action='store', type=str, help='List of host:port
 parser.add_argument('--delay', type=float, default=0.0, help='Amount of seconds (float) to sleep between attempts')
 
 def send_name(name):
-  return pack('!HcHI', 7 + len(name), 'n', 5, 0x3499c) + name
+  return pack('!HcHI', 7 + len(name), 'n', 5, 0x7499c) + name
 
 def send_challenge_reply(cookie, challenge):
   m = md5()


### PR DESCRIPTION
I spent a bit of time chasing this down and got it working for a couple of test systems with a different set of capability flags. Namely, just setting DFLAG_BIG_CREATION which changes the value from 0x3499c to 0x7499c. Hope this helps!

```
0x0007499c == 0b0000 0000 0111 0100 1001 1001 1100
                   |       |||  |   |  | |  | ||-- DFLAG_EXTENDED_REFERENCES
                   |       |||  |   |  | |  | |-- DFLAG_DIST_MONITOR
                   |       |||  |   |  | |  |-- DFLAG_FUN_TAGS
                   |       |||  |   |  | |-- DFLAG_NEW_FUN_TAGS 
                   |       |||  |   |  |-- DFLAG_EXTENDED_PIDS_PORTS 
                   |       |||  |   |-- DFLAG_NEW_FLOATS 
                   |       |||  |-- DFLAG_SMALL_ATOM_TAGS
                   |       |||-- DFLAG__UTF8_ATOMS
                   |       ||-- DFLAG_MAP_TAG 
                   |       |-- **DFLAG_BIG_CREATION**
                   |-- DFLAG_HANDSHAKE_23
```
