### PR TITLE
Fix revert-prng support for newer sage versions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -13,6 +13,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 
 Copyright (c) 2010 Serge A. Zaitsev
+Copyright (c) 2020 Joachim Vandersmissen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Hi !

It turns out that this repository is still useful :).

I took at stab at fixing #4, so that the script `revert-prng.sage` works for new sage versions.
This commit is mainly code from the great [jvdsn/crypto-attacks](https://github.com/jvdsn/crypto-attacks/blob/master/attacks/lcg/truncated_state_recovery.py) repository, slightly modified to match the state truncation. 

The function could be optimized, precomputing the `delta`s or the `B` matrix since all the parameters are fixed, but I guess it's good enough for the basic use cases.